### PR TITLE
Added Electrochemical Characterization Methods

### DIFF
--- a/chameo.ttl
+++ b/chameo.ttl
@@ -128,6 +128,8 @@ foaf:page rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
+
+
 ###  http://emmo.info/emmo/domain/chameo/chameo#characterisationProcedureHasSubProcedure
 chameo:characterisationProcedureHasSubProcedure rdf:type owl:ObjectProperty ;
                                                 rdfs:subPropertyOf emmo:EMMO_d43af210_f854_4432_a891_ce3022e3b558 ;
@@ -468,7 +470,503 @@ chameo:AlphaSpectrometry rdf:type owl:Class ;
 chameo:Amperometry rdf:type owl:Class ;
                    rdfs:subClassOf chameo:Electrochemical ;
                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "The amperometric method provides the ability to distinguish selectively between a number of electroactive species in solution by judicious selection of the applied potential and/or choice of electrode material."@en ;
+                   emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                                       rdfs:comment "Amperometry can be distinguished from voltammetry by the parameter being controlled (electrode potential E) and the parameter being measured (electrode current I which is usually a function of time – see chronoamperometry)."@en ,
+                                                                    "In a non-stirred solution, a diffusion-limited current is usually measured, which is propor-tional to the concentration of an electroactive analyte."@en ,
+                                                                    "The current is usually faradaic and the applied potential is usually constant."@en ,
+                                                                    "The integral of current with time is the electric charge, which may be related to the amount of substance reacted by Faraday’s laws of electrolysis."@en ;
                    skos:prefLabel "Amperometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Conductometry
+chameo:Conductometry rdf:type owl:Class ;
+                rdfs:subClassOf chameo:Electrochemical ;
+                emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q901180" ;
+                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "measurement principle in which the electric conductivity of a solution is measured"@en ;
+                emmo:EMMO_b432d2d5_25f4_4165_99c5_5935a7763c1a "Monitoring of the purity of deionized water."@en ;
+                emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Conductometry"@en ;
+                emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                rdfs:comment "The conductivity of a solution depends on the concentration and nature of ions present."@en ;
+                skos:prefLabel "Conductometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Coulometry
+chameo:Coulometry rdf:type owl:Class ;
+            rdfs:subClassOf chameo:Electrochemical ;
+            emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1136979" ;
+            emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f "https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=114-04-13" ;
+            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical measurement principle in which the electric charge required to carry out a known electrochemical reaction is measured. By Faraday’s laws of electrolysis, the amount of substance is proportional to the charge"@en ;
+            emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Coulometry"@en ;
+            emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+            rdfs:comment "Coulometry used to measure the amount of substance is a primary reference measurement procedure [VIM 2.8] not requiring calibration with a standard for a quantity of the same kind (i.e. amount of substance)."@en ,
+                        "The coulometric experiment can be carried out at controlled (constant) potential (see direct coulometry at controlled potential) or controlled (constant) current (see direct coulometry at controlled current)."@en ;
+            skos:prefLabel "Coulometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Chronoamperometry
+chameo:Chronoamperometry rdf:type owl:Class ;
+                    rdfs:subClassOf chameo:Amperometry;
+                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "amperometry in which the current is measured as a function of time after a change in the applied potential"@en ;
+                    emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                    rdfs:comment "If the potential step is from a potential at which no current flows (i.e., at which the oxidation or reduction of the electrochemically active species does not take place) to one at which the current is limited by diffusion (see diffusion-limited current), the current obeys the Cottrell equation."@en ;
+                    skos:altLabel "AmperiometricDetection"@en ,
+                                  "AmperometricCurrentTimeCurve"@en ;
+                    skos:prefLabel "Chronoamperometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#ConductometricTitration
+chameo:ConductometricTitration rdf:type owl:Class ;
+                                rdfs:subClassOf chameo:Conductometry ;
+                                emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11778221" ;
+                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "titration in which the electric conductivity of a solution is measured as a function of the amount of titrant added"@en ;
+                                emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                rdfs:comment "The equivalence-point is obtained as the intersection of linear parts of the conductance G, versus titrant volume V, curve (see"@en ,
+                                            "The method can be used for deeply coloured or turbid solutions. Acid-base and precipita- tion reactions are most frequently used."@en ,
+                                            "The method is based on replacing an ionic species of the analyte with another species, cor- responding to the titrant or the product with significantly different conductance."@en ;
+                                skos:prefLabel "ConductometricTitration"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Chronocoulometry
+chameo:Chronocoulometry rdf:type owl:Class ;
+                                rdfs:subClassOf chameo:Coulometry ;
+                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "direct coulometry at controlled potential in which the electric charge passed after the application of a potential step perturbation is measured as a function of time (Q-t curve)"@en ;
+                                emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                rdfs:comment "Chronocoulometry provides the same information that is provided by chronoamperometry, since it is based on the integration of the I-t curve. Nevertheless, chronocoulometry offers important experimental advantages, such as (i) the measured signal usually increases with time and hence the later parts of the transient can be detected more accurately, (ii) a better signal-to-noise ratio can be achieved, and (iii) other contributions to overall charge passed as a function of time can be discriminated from those due to the diffusion of electroactive substances."@en ;
+                                skos:prefLabel "Chronocoulometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#CoulometricTitration
+chameo:CoulometricTitration rdf:type owl:Class ;
+                        rdfs:subClassOf chameo:Coulometry ;
+                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "titration in which the titrant is generated electrochemically, either by constant current or at constant potential. The titrant reacts stoichiometrically with the analyte, the amount of which is calculated using Faraday’s laws of electrolysis from the electric charge required to reach the end-point"@en ;
+                        rdfs:comment "Coulometric titrations are usually carried out in convective mass transfer mode using a large surface working electrode. The reference and auxiliary electrodes are located in sepa- rate compartments. A basic requirement is a 100 % current efficiency of titrant generation at the working electrode. End-point detection can be accomplished with potentiometry, amperometry, biamperometry, bipotentiometry, photometry, or by using a visual indicator."@en ,
+                                    "The main advantages are that titration is possible with less stable titrants, the standardi- zation of titrant is not necessary, the volume of the test solution is not changed, and the method is easily automated."@en ;
+                        skos:prefLabel "CoulometricTitration"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#DirectCoulometryAtControlledCurrent
+chameo:DirectCoulometryAtControlledCurrent rdf:type owl:Class ;
+                                            rdfs:subClassOf chameo:Coulometry ;
+                                            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "coulometry at an imposed, constant current in the electrochemical cell"@en ;
+                                            rdfs:comment "Direct coulometry at controlled current is usually carried out in convective mass transfer mode. The end-point of the electrolysis, at which the current is stopped, must be determined either from the inflection point in the E–t curve or by using visual or objective end-point indi- cation, similar to volumetric methods. The total electric charge is calculated as the product of the constant current and time of electrolysis or can be measured directly using a coulometer."@en ,
+                                                        "The advantage of this method is that the electric charge consumed during the electrode reaction is directly proportional to the electrolysis time. Care must be taken to avoid the potential region where another electrode reaction may occur."@en ;
+                                            skos:prefLabel "DirectCoulometryAtControlledCurrent"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#DirectCoulometryAtControlledPotential
+chameo:DirectCoulometryAtControlledPotential rdf:type owl:Class ;
+                                              rdfs:subClassOf chameo:Coulometry ;
+                                              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "coulometry at a preselected constant potential of the working electrode"@en ;
+                                              emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                              rdfs:comment "Direct coulometry at controlled potential is usually carried out in convective mass trans- fer mode using a large surface working electrode. Reference and auxiliary electrodes are placed in separate compartments. The total electric charge is obtained by integration of the I–t curve or can be measured directly using a coulometer."@en ,
+                                                          "In principle, the end point at which I = 0, i.e. when the concentration of species under study becomes zero, can be reached only at infinite time. However, in practice, the electrolysis is stopped when the current has decayed to a few percent of the initial value and the charge passed at infinite time is calculated from a plot of charge Q(t) against time t. For a simple system under diffusion control Qt= Q∞[1 − exp(−DAt/Vδ)], where Q∞ = limt→∞Q(t) is the total charge passed at infinite time, D is the diffusion coefficient of the electroactive species, A the electrode area, δ the diffusion layer thickness, and V the volume of the solution."@en ;
+                                              skos:prefLabel "DirectCoulometryAtControlledPotential"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#ElectrochemicalPiezoelectricMicrogravimetry
+chameo:ElectrochemicalPiezoelectricMicrogravimetry rdf:type owl:Class ;
+                                                    rdfs:subClassOf chameo:Electrogravimetry ;
+                                                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Electrogravimetry using an electrochemical quartz crystal microbalance."@en ;
+                                                    emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                                    rdfs:comment "The change of mass is, for rigid deposits, linearly proportional to the change of the reso- nance frequency of the quartz crystal, according to the Sauerbrey equation. For non- rigid deposits, corrections must be made."@en ;
+                                                    skos:prefLabel "ElectrochemicalPiezoelectricMicrogravimetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#ElectrochemicalImpedanceSpectroscopy
+chameo:ElectrochemicalImpedanceSpectroscopy rdf:type owl:Class ;
+                                            rdfs:subClassOf chameo:Impedimetry ;
+                                            emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3492904"@en ;
+                                            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical measurement method of the complex impedance of an electrochemical system as a function of the frequency of a small amplitude (normally 5 to 10 mV) sinusoidal voltage perturbation superimposed on a fixed value of applied potential or on the open circuit potential"@en ;
+                                            emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                            rdfs:comment "Impedimetric sensors are based on measurement of a concentration-dependent parameter taken from analysis of the respective electrochemical impedance spectra, or from the impedance magnitudes at a chosen fixed frequency."@en ,
+                                                        "The sinusoidal current response lags behind the sinusoidal voltage perturbation by a phase angle φ. Resistances (e.g. to charge transfer) give a response in phase with the voltage perturbation; capacitances (e.g. double layer) give a response 90° out of phase; combinations of resistances and capacitances give phase angles between 0 and 90°. Plots of the out of phase vs. the in phase component of the impedance for all the frequencies tested are called complex plane (or Nyquist) plots. Plots of the phase angle and the magnitude of the impedance vs. the logarithm of perturbation frequency are called Bode diagrams. Complex plane plots are the more commonly used for electrochemical sensors."@en ;
+                                            skos:altLabel "EIS"@en ;
+                                            skos:prefLabel "ElectrochemicalImpedanceSpectroscopy"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Chronopotentiometry
+chameo:Chronopotentiometry rdf:type owl:Class ;
+                            rdfs:subClassOf chameo:Potentiometry ;
+                            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "potentiometry in which the potential is measured with time following a change in applied current"@en ;
+                            emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                            rdfs:comment "The change in applied current is usually a step, but cyclic current reversals or linearly increasing currents are also used."@en ;
+                            skos:prefLabel "Chronopotentiometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#CyclicChronopotentiometry
+chameo:CyclicChronopotentiometry rdf:type owl:Class ;
+                                  rdfs:subClassOf chameo:Chronopotentiometry ;
+                                  emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "chronopotentiometry where the change in applied current undergoes a cyclic current reversal"@en ;
+                                  skos:prefLabel "CyclicChronopotentiometry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:CyclicChronopotentiometry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "chronopotentiometry where the change in applied current undergoes a cyclic current reversal"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109."
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#GITT
+chameo:GITT rdf:type owl:Class ;
+            rdfs:subClassOf chameo:Chronopotentiometry ;
+            emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q120906986" ;
+            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical method that applies current pulses to an electrochemical cell at rest and measures the voltage response"@en ;
+            skos:altLabel "GalvanostaticIntermittentTitrationTechnique"@en ;
+            skos:prefLabel "GITT"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#HPPC
+chameo:HPPC rdf:type owl:Class ;
+            rdfs:subClassOf chameo:Chronopotentiometry ;
+            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical method that measures the voltage drop of a cell resulting from a square wave current load"@en ;
+            skos:altLabel "HybridPulsePowerCharacterisation"@en ,
+                          "HybridPulsePowerCharacterization"@en ;
+            skos:prefLabel "HPPC"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#ICI
+chameo:ICI rdf:type owl:Class ;
+            rdfs:subClassOf chameo:Chronopotentiometry ;
+            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical method that measures the voltage response of an electrochemical cell under galvanostatic conditions to short interruptions in the current"@en ;
+            skos:altLabel "IntermittentCurrentInterruptionMethod"@en ;
+            skos:prefLabel "ICI"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#LinearChronopotentiometry
+chameo:LinearChronopotentiometry rdf:type owl:Class ;
+                                  rdfs:subClassOf chameo:Chronopotentiometry ;
+                                  emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "chronopotentiometry where the applied current is changed linearly"@en ;
+                                  skos:prefLabel "LinearChronopotentiometry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:LinearChronopotentiometry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "chronopotentiometry where the applied current is changed linearly"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109."
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#OpenCircuitHold
+chameo:OpenCircuitHold rdf:type owl:Class ;
+                        rdfs:subClassOf chameo:Potentiometry ;
+                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "a process in which the electric current is kept constant at 0 (i.e., open-circuit conditions)"@en ;
+                        skos:altLabel "OCVHold"@en ;
+                        skos:prefLabel "OpenCircuitHold"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#AbrasiveStrippingVoltammetry
+chameo:AbrasiveStrippingVoltammetry rdf:type owl:Class ;
+                                    rdfs:subClassOf chameo:Voltammetry ;
+                                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical method where traces of solid particles are abrasively transferred onto the surface of an electrode, followed by an electrochemical dissolution (anodic or cathodic dissolution) that is recorded as a current–voltage curve"@en ;
+                                    skos:prefLabel "AbrasiveStrippingVoltammetry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:AbrasiveStrippingVoltammetry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "electrochemical method where traces of solid particles are abrasively transferred onto the surface of an electrode, followed by an electrochemical dissolution (anodic or cathodic dissolution) that is recorded as a current–voltage curve"@en ;
+   dcterms:source "Scholz F, Nitschke L, Henrion G (1989) Naturwiss 76:71;"
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#ACVoltammetry
+chameo:ACVoltammetry rdf:type owl:Class ;
+                      rdfs:subClassOf chameo:Voltammetry ;
+                      emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q120895154" ;
+                      emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "voltammetry in which a sinusoidal alternating potential of small amplitude (10 to 50 mV) of constant frequency (10 Hz to 100 kHz) is superimposed on a slowly and linearly varying potential ramp"@en ;
+                      emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                      rdfs:comment "The resulting alternating current is plotted versus imposed DC potential. The obtained AC voltammogram is peak-shaped."@en ;
+                      skos:altLabel "ACV"@en ;
+                      skos:prefLabel "ACVoltammetry"@en .
+
+
+###  https://w3id.org/emmo/domain/electrochemistry#StepChronopotentiometry
+chameo:StepChronopotentiometry rdf:type owl:Class ;
+                                rdfs:subClassOf chameo:Chronopotentiometry ;
+                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "chronopotentiometry where the applied current is changed in steps"@en ;
+                                skos:prefLabel "StepChronopotentiometry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:StepChronopotentiometry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "chronopotentiometry where the applied current is changed in steps"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109."
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#CyclicVoltammetry
+chameo:CyclicVoltammetry rdf:type owl:Class ;
+                          rdfs:subClassOf chameo:Voltammetry ;
+                          emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1147647" ;
+                          emmo:EMMO_6dd685dd_1895_46e4_b227_be9f7d643c25 "https://dbpedia.org/page/Cyclic_voltammetry"^^xsd:anyURI ;
+                          emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "voltammetry in which the electric current is recorded as the electrode potential is varied with time cycli- cally between two potential limits, normally at a constant scan rate"@en ;
+                          emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Cyclic_voltammetry"^^xsd:anyURI ;
+                          emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                          rdfs:comment "Cyclic voltammetry is frequently used for the investigation of mechanisms of electrochemi- cal/electrode reactions. The current-potential curve may be modelled to obtain reaction mechanisms and electrochemical parameters."@en ,
+                                      "Normally the initial potential is chosen where no electrode reaction occurs and the switch- ing potential is greater (more positive for an oxidation or more negative for a reduction) than the peak potential of the analyte reaction."@en ,
+                                      "The initial potential is usually the negative or positive limit of the cycle but can have any value between the two limits, as can the initial scan direction. The limits of the potential are known as the switching potentials."@en ,
+                                      "The plot of current against potential is termed a cyclic voltammogram. Usually peak-shaped responses are obtained for scans in both directions."@en ;
+                          skos:altLabel "CV"@en ;
+                          skos:prefLabel "CyclicVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#DCPolarography
+chameo:DCPolarography rdf:type owl:Class ;
+                      rdfs:subClassOf chameo:Voltammetry ;
+                      emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "linear scan voltammetry with slow scan rate in which a dropping mercury electrode is used as the working electrode"@en ;
+                      emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                      rdfs:comment "If the whole scan is performed on a single growing drop, the technique should be called single drop scan voltammetry. The term polarography in this context is discouraged."@en ,
+                                  "This is the oldest variant of polarographic techniques, introduced by Jaroslav Heyrovský (1890 – 1967)."@en ,
+                                  "Usually the drop time is between 1 and 5 s and the pseudo-steady-state wave-shaped dependence on potential is called a polarogram. If the limiting current is controlled by dif- fusion, it is expressed by the Ilkovich equation."@en ;
+                      skos:prefLabel "DCPolarography"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#SampledDCPolarography
+chameo:SampledDCPolarography rdf:type owl:Class ;
+                              rdfs:subClassOf chameo:DCPolarography ;
+                              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "DC polarography with current sampling at the end of each drop life mechanically enforced by a knocker at a preset drop time value. The current sampling and mechanical drop dislodge are synchronized."@en ;
+                              emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                              rdfs:comment "In this way, the ratio of faradaic current to double layer charging current is enhanced and the negative influence of charging current is partially eliminated. Due to the improved signal (faradaic current) to noise (charging current) ratio, the limit of detection is lowered."@en ;
+                              skos:altLabel "TASTPolarography"@en ;
+                              skos:prefLabel "SampledDCPolarography"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#DifferentialPulseVoltammetry
+chameo:DifferentialPulseVoltammetry rdf:type owl:Class ;
+                                    rdfs:subClassOf chameo:Voltammetry ;
+                                    emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q5275361" ;
+                                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "voltammetry in which small potential pulses (constant height 10 to 100 mV, constant width 10 to 100 ms) are superimposed onto a linearly varying potential or onto a staircase potential ramp. The current is sampled just before the onset of the pulse (e.g. 10 to 20 ms) and for the same sampling time just before the end of the pulse. The difference between the two sampled currents is plotted versus the potential applied before the pulse. Thus, a differential pulse voltammogram is peak-shaped"@en ;
+                                    emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Differential_pulse_voltammetry"@en ;
+                                    emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                    rdfs:comment "Differential pulse polarography is differential pulse voltammetry in which a dropping mercury electrode is used as the working electrode. A pulse is applied before the mechani- cally enforced end of the drop and the current is sampled twice: just before the onset of the pulse and just before its end. The pulse width is usually 10 to 20 % of the drop life. The drop dislodgement is synchronized with current sampling, which is carried out as in DPV."@en ,
+                                                "The ratio of faradaic current to charging current is enhanced and the negative influence of charging current is partially eliminated in the same way as in normal pulse voltammetry (NPV). Moreover, subtraction of the charging current sampled before the application of the pulse further decreases its negative influence. Due to the more enhanced signal (faradaic current) to noise (charging current) ratio, the limit of detection is lower than with NPV."@en ,
+                                                "The sensitivity of DPV depends on the reversibility of the electrode reaction of the analyte."@en ;
+                                    skos:altLabel "DPV"@en ;
+                                    skos:prefLabel "DifferentialPulseVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#DifferentialLinearPulseVoltammetry
+chameo:DifferentialLinearPulseVoltammetry rdf:type owl:Class ;
+                                          rdfs:subClassOf chameo:DifferentialPulseVoltammetry ;
+                                          emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Differential Pulse Voltammetry in which small potential pulses are superimposed onto a linearly varying potential."@en ;
+                                          skos:prefLabel "DifferentialLinearPulseVoltammetry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:DifferentialLinearPulseVoltammetry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "Differential Pulse Voltammetry in which small potential pulses are superimposed onto a linearly varying potential."@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#DifferentialStaircasePulseVoltammetry
+chameo:DifferentialStaircasePulseVoltammetry rdf:type owl:Class ;
+                                              rdfs:subClassOf chameo:DifferentialPulseVoltammetry ;
+                                              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Differential Pulse Voltammetry in which small potential pulses are superimposed onto a staircase potential ramp."@en ;
+                                              skos:prefLabel "DifferentialStaircasePulseVoltammetry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:DifferentialStaircasePulseVoltammetry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "Differential Pulse Voltammetry in which small potential pulses are superimposed onto a staircase potential ramp."@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#HydrodynamicVoltammetry
+chameo:HydrodynamicVoltammetry rdf:type owl:Class ;
+                                rdfs:subClassOf chameo:Voltammetry ;
+                                emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q17028237" ;
+                                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "voltammetry with forced flow of the solution towards the electrode surface"@en ;
+                                emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Hydrodynamic_voltammetry"@en ;
+                                emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                rdfs:comment "A linear potential scan, at sufficiently slow scan rates so as to ensure a steady state response, is usually applied."@en ,
+                                            "Mass transport of a redox species enhanced by convection in this way results in a greater electric current. Convective mass transfer occurs up to the diffusion-limiting layer, within which the mass transfer is controlled by diffusion. Electroactive substance depletion outside the diffusion layer is annulled by convective mass transfer, which results in steady- state sigmoidal wave-shaped current-potential curves."@en ,
+                                            "The forced flow can be accomplished by movement either of the solution (solution stirring, or channel flow), or of the electrode (electrode rotation or vibration)."@en ;
+                                skos:prefLabel "HydrodynamicVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#VoltammetryAtARotatingDiskElectrode
+chameo:VoltammetryAtARotatingDiskElectrode rdf:type owl:Class ;
+                                            rdfs:subClassOf chameo:HydrodynamicVoltammetry ;
+                                            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "hydrodynamic voltammetry using a a rotating disc electrode, where the limiting current is described by the Levich equation"@en ;
+                                            emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                            skos:prefLabel "VoltammetryAtARotatingDiskElectrode"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#LinearScanVoltammetry
+chameo:LinearScanVoltammetry rdf:type owl:Class ;
+                              rdfs:subClassOf chameo:Voltammetry ;
+                              emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q620700" ;
+                              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Voltammetry in which the current is recorded as the electrode potential is varied linearly with time."@en ;
+                              emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Linear_sweep_voltammetry"^^xsd:anyURI ;
+                              emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                              rdfs:comment "LSV corresponds to the first half cycle of cyclic voltammetry."@en ,
+                                          "The peak current is expressed by the Randles-Ševčík equation."@en ,
+                                          "The scan is usually started at a potential where no electrode reaction occurs."@en ;
+                              skos:altLabel "LSV"@en ,
+                                            "LinearPolarization"@en ,
+                                            "LinearSweepVoltammetry"@en ;
+                              skos:prefLabel "LinearScanVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#NormalPulseVoltammetry
+chameo:NormalPulseVoltammetry rdf:type owl:Class ;
+                              rdfs:subClassOf chameo:Voltammetry ;
+                              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "voltammetry in which potential pulses of amplitude increasing by a constant increment and with a pulse width of 2 to 200 ms are superimposed on a constant initial potential"@en ;
+                              emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                              rdfs:comment "Normal pulse polarography is NPV in which a dropping mercury electrode is used as the working electrode. A pulse is applied just before the mechanically enforced end of the drop. The pulse width is usually 10 to 20 % of the drop time. The drop dislodgment is synchro- nized with current sampling, which is carried out just before the end of the pulse, as in NPV."@en ,
+                                          "Sigmoidal wave-shaped voltammograms are obtained."@en ,
+                                          "The current is sampled at the end of the pulse and then plotted versus the potential of the pulse."@en ,
+                                          "The current is sampled just before the end of the pulse, when the charging current is greatly diminished. In this way, the ratio of faradaic current to charging current is enhanced and the negative influence of charging current is partially eliminated. Due to the improved signal (faradaic current) to noise (charging current) ratio, the limit of detec- tion is lowered."@en ,
+                                          "The sensitivity of NPV is not affected by the reversibility of the electrode reaction of the analyte."@en ;
+                              skos:altLabel "NPV"@en ;
+                              skos:prefLabel "NormalPulseVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#PotentiometricStrippingAnalysis
+chameo:PotentiometricStrippingAnalysis rdf:type owl:Class ;
+                                        rdfs:subClassOf chameo:Voltammetry ;
+                                        emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "two-step electrochemical measurement in which 1) material is accumulated at an electrode and 2) the material is removed by chemical reaction or electrochemically at constant current with measurement of electrode potential"@en ;
+                                        rdfs:comment "historically for the analysis of metal ions, mercury ions were added to the test solution to form a mercury amalgam when reduced. Alternatively, an HMDE or MFE was used and the oxidizing agent added after amalgam formation. However, the toxicity of mercury and its compounds have all but precluded the present-day use of mercury"@en ,
+                                                    "the accumulation is similar to that used in stripping voltammetry"@en ,
+                                                    "the stripping potentiogram shows staircase curves of potential as a function of time. Frequently, the first derivative is displayed (dE/dt=f(t)), as this produces peak-shaped signals. The time between transitions (peaks) is proportional to the concentration of analyte in the test solution"@en ,
+                                                    "the time between changes in potential in step 2 is related to the concentration of analyte in the solution"@en ;
+                                        skos:altLabel "PSA"@en ;
+                                        skos:prefLabel "PotentiometricStrippingAnalysis"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:PotentiometricStrippingAnalysis ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "two-step electrochemical measurement in which 1) material is accumulated at an electrode and 2) the material is removed by chemical reaction or electrochemically at constant current with measurement of electrode potential"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:PotentiometricStrippingAnalysis ;
+   owl:annotatedProperty rdfs:comment ;
+   owl:annotatedTarget "historically for the analysis of metal ions, mercury ions were added to the test solution to form a mercury amalgam when reduced. Alternatively, an HMDE or MFE was used and the oxidizing agent added after amalgam formation. However, the toxicity of mercury and its compounds have all but precluded the present-day use of mercury"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:PotentiometricStrippingAnalysis ;
+   owl:annotatedProperty rdfs:comment ;
+   owl:annotatedTarget "the accumulation is similar to that used in stripping voltammetry"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:PotentiometricStrippingAnalysis ;
+   owl:annotatedProperty rdfs:comment ;
+   owl:annotatedTarget "the stripping potentiogram shows staircase curves of potential as a function of time. Frequently, the first derivative is displayed (dE/dt=f(t)), as this produces peak-shaped signals. The time between transitions (peaks) is proportional to the concentration of analyte in the test solution"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:PotentiometricStrippingAnalysis ;
+   owl:annotatedProperty rdfs:comment ;
+   owl:annotatedTarget "the time between changes in potential in step 2 is related to the concentration of analyte in the solution"@en ;
+   dcterms:source "J. M. Pingarrón et al., Terminology of electrochemical methods of analysis (IUPAC Recommendations 2019), Pure and Applied Chemistry, 4, 92, 2020, 641-694. https://doi.org/10.1515/pac-2018-0109"
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#SquareWaveVoltammetry
+chameo:SquareWaveVoltammetry rdf:type owl:Class ;
+                              rdfs:subClassOf chameo:Voltammetry ;
+                              emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4016323" ;
+                              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "voltammetry in which a square-wave potential waveform is superimposed on an underlying linearly varying potential ramp or staircase ramp"@en ;
+                              emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Squarewave_voltammetry"@en ;
+                              emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                              rdfs:comment "Most instruments show plots of the current at the end of the forward-going pulse and of the backward-going pulse vs. the potential, as well as their difference. This can give valuable information on the kinetics of the electrode reaction and the electrode process."@en ,
+                                          "The current is sampled just before the end of the forward- going pulse and of the backward-going pulse and the difference of the two sampled currents is plotted versus the applied potential of the potential or staircase ramp. The square-wave voltammogram is peak-shaped"@en ,
+                                          "The sensitivity of SWV depends on the reversibility of the electrode reaction of the analyte."@en ;
+                              skos:altLabel "OSWV"@en ,
+                                            "OsteryoungSquareWaveVoltammetry"@en ,
+                                            "SWV"@en ;
+                              skos:prefLabel "SquareWaveVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#StrippingVoltammetry
+chameo:StrippingVoltammetry rdf:type owl:Class ;
+                            rdfs:subClassOf chameo:Voltammetry ;
+                            emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "two-step electrochemical measurement in which 1) material is accumulated at an electrode and 2) the amount of an accumulated species is measured by voltammetry. The measured electric current in step 2 is related to the concentration of analyte in the solution by calibration."@en ;
+                            emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Electrochemical_stripping_analysis"@en ;
+                            emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                            rdfs:comment "Anodic stripping voltammetry (ASV) was historically used to measure concentrations of metal ions in solution using cathodic accumulation with mercury to form an amalgam. Due to the toxicity of mercury and its compounds, inductively coupled plasma optical emission spectrometry and inductively coupled plasma mass spectrometry have frequently replaced ASV at mercury electrodes in the laboratory, often sacrificing the probing of speciation and lability in complex matrices. Mercury has now been replaced by non-toxic bismuth or anti- mony as films on a solid electrode support (such as glassy carbon) with equally good sensi- tivity and detection limits."@en ,
+                                        "Because the accumulation (pre-concentration) step can be prolonged, increasing the amount of material at the electrode, stripping voltammetry is able to measure very small concentrations of analyte."@en ,
+                                        "Often the product of the electrochemical stripping is identical to the analyte before the accumulation."@en ,
+                                        "Stripping voltammetry is a calibrated method to establish the relation between amount accumulated in a given time and the concentration of the analyte in solution."@en ,
+                                        "Types of stripping voltammetry refer to the kind of accumulation (e.g. adsorptive stripping voltammetry) or the polarity of the stripping electrochemistry (anodic, cathodic stripping voltammetry)."@en ;
+                            skos:prefLabel "StrippingVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#AdsorptiveStrippingVoltammetry
+chameo:AdsorptiveStrippingVoltammetry rdf:type owl:Class ;
+                                      rdfs:subClassOf chameo:StrippingVoltammetry ;
+                                      emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Stripping voltammetry involving pre-concentration by adsorption of the analyte (in contrast to electro- chemical accumulation)."@en ;
+                                      emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                      rdfs:comment "A peak-shaped adsorptive stripping voltammogram is obtained. Peak current depends on time of accumulation, mass transport of analyte (stirring), scan rate and mode (linear or pulse), and analyte concentration in solution."@en ,
+                                                  "AdSV is usually employed for analysis of organic compounds or metal complexes with organic ligands. Stripping is done by means of an anodic or a cathodic voltammetric scan (linear or pulse), during which the adsorbed compound is oxidized or reduced."@en ;
+                                      skos:altLabel "AdSV"@en ;
+                                      skos:prefLabel "AdsorptiveStrippingVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#AnodicStrippingVoltammetry
+chameo:AnodicStrippingVoltammetry rdf:type owl:Class ;
+                                  rdfs:subClassOf chameo:StrippingVoltammetry ;
+                                  emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q939328" ;
+                                  emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Stripping voltammetry in which material accumulated at the working electrode is electrochemically oxi- dized in the stripping step."@en ;
+                                  emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                  rdfs:comment "A peak-shaped anodic stripping voltammogram is obtained. Peak current depends on time of accumulation, mass transport of analyte (stirring), scan rate and mode (linear or pulse), and analyte concentration in solution."@en ,
+                                              "A solid electrode, carbon paste or composite electrode, bismuth film electrode, mercury film electrode, or static mercury drop electrode may be used."@en ;
+                                  skos:prefLabel "AnodicStrippingVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#CathodicStrippingVoltammetry
+chameo:CathodicStrippingVoltammetry rdf:type owl:Class ;
+                                    rdfs:subClassOf chameo:StrippingVoltammetry ;
+                                    emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4016325" ;
+                                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "stripping voltammetry in which material accumulated at the working electrode is electrochemically reduced in the stripping step"@en ;
+                                    emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                                    rdfs:comment "A peak-shaped cathodic stripping voltammogram is obtained. Peak current depends on time of accumulation, mass transport of analyte (stirring), scan rate and mode (linear or pulse), and analyte concentration in solution."@en ;
+                                    skos:altLabel "CSV"@en ;
+                                    skos:prefLabel "CathodicStrippingVoltammetry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Dielectrometry
+chameo:Dielectrometry rdf:type owl:Class ;
+                rdfs:subClassOf chameo:Electrochemical ;
+                emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "electrochemical measurement principle based on the measurement of the dielectric constant of a sample resulting from the orientation of particles (molecules or ions) that have a dipole moment in an electric field"@en ;
+                emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                rdfs:comment "Dielectrometric titrations use dielectrometry for the end-point detection."@en ,
+                            "The method is used to monitor the purity of dielectrics, for example to detect small amounts of moisture."@en ;
+                skos:prefLabel "Dielectrometry"@en .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Electrogravimetry
+chameo:Electrogravimetry rdf:type owl:Class ;
+                    rdfs:subClassOf chameo:Electrochemical ;
+                    emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q902953" ;
+                    emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f "https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=114-04-14"@en ;
+                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "method of electroanalytical chemistry used to separate by electrolyse ions of a substance and to derive the amount of this substance from the increase in mass of an electrode."@en ;
+                    emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Electrogravimetry"@en ;
+                    skos:prefLabel "Electrogravimetry"@en .
+
+[ rdf:type owl:Axiom ;
+   owl:annotatedSource chameo:Electrogravimetry ;
+   owl:annotatedProperty emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 ;
+   owl:annotatedTarget "method of electroanalytical chemistry used to separate by electrolyse ions of a substance and to derive the amount of this substance from the increase in mass of an electrode."@en ;
+   dcterms:source "International Electrotechnical Commission (IEC), IEC 60050 - International Electrotechnical Vocabulary, retrieved from: https://www.electropedia.org"
+ ] .
+
+
+###  http://emmo.info/emmo/domain/chameo/chameo#Impedimetry
+chameo:Impedimetry rdf:type owl:Class ;
+              rdfs:subClassOf chameo:Electrochemical ;
+              emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "measurement principle in which the complex electric impedance of a system is measured, usually as a function of a small amplitude sinusoidal electrode potential"@en ;
+              emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+              skos:prefLabel "Impedimetry"@en .
 
 
 ###  http://emmo.info/emmo/domain/chameo/chameo#AnalyticalElectronMicroscopy
@@ -1298,6 +1796,11 @@ chameo:PostProcessingModel rdf:type owl:Class ;
 ###  http://emmo.info/emmo/domain/chameo/chameo#Potentiometry
 chameo:Potentiometry rdf:type owl:Class ;
                      rdfs:subClassOf chameo:Electrochemical ;
+                     emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q900632" ;
+                     emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f "https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=114-04-12" ;
+                     emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                     rdfs:comment "For measurements using ion-selective electrodes, the measurement is made under equi- librium conditions what means that the macroscopic electric current is zero and the con- centrations of all species are uniform throughout the solution. The indicator electrode is in direct contact with the analyte solution, whereas the reference electrode is usually separated from the analyte solution by a salt bridge. The potential difference between the indicator and reference electrodes is normally directly proportional to the logarithm of the activity (concentration) of the analyte in the solution (Nernst equation). See also ion selec- tive electrode."@en ,
+                                                                    "Method of electroanalytical chemistry based on measurement of an electrode potential."@en ;
                      emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Potentiometric methods are used to measure the electrochemical potentials of a metallic structure in a given environment."@en ;
                      skos:prefLabel "Potentiometry"@en .
 
@@ -1656,6 +2159,11 @@ chameo:Viscometry rdf:type owl:Class ;
 ###  http://emmo.info/emmo/domain/chameo/chameo#Voltammetry
 chameo:Voltammetry rdf:type owl:Class ;
                    rdfs:subClassOf chameo:Electrochemical ;
+                   emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q904093" ;
+                   emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f "https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=114-04-11" ;
+                   emmo:EMMO_c84c6752_6d64_48cc_9500_e54a3c34898d "https://en.wikipedia.org/wiki/Voltammetry" ;
+                   emmo:EMMO_fe015383_afb3_44a6_ae86_043628697aa2 "https://doi.org/10.1515/pac-2018-0109"@en ;
+                   rdfs:comment "The current vs. potential (I-E) curve is called a voltammogram."@en ;
                    emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "Voltammetry is an analytical technique based on the measure of the current flowing through an electrode dipped in a solution containing electro-active compounds, while a potential scanning is imposed upon it."@en ;
                    skos:prefLabel "Voltammetry"@en .
 


### PR DESCRIPTION
This PR adds electrochemical characterization methods from domain-electrochemistry. The goal is to move terms that describe electrochemical characterization methods to CHAMEO and then import CHAMEO into domain-electrochemistry and domain-battery. This should also support tighter integration with the work on battery testing. 